### PR TITLE
Overwrite the service worker, offline, and icons files/folders

### DIFF
--- a/R/pwa.R
+++ b/R/pwa.R
@@ -42,15 +42,18 @@ set_pwa <- function(path, name = "My Progressive Web App", shortName = "My App",
   # copy service worker + offline templates + icons
   fs::file_copy(
     system.file("pwa-utils/js/service-worker.js", package = "charpente"),
-    paste0(path, "/www")
+    paste0(path, "/www"),
+    overwrite = TRUE
   )
   fs::file_copy(
     system.file("pwa-utils/html/offline.html", package = "charpente"),
-    paste0(path, "/www")
+    paste0(path, "/www"),
+    overwrite = TRUE
   )
   fs::dir_copy(
     system.file("pwa-utils/icons", package = "charpente"),
-    paste0(path, "/www/icons")
+    paste0(path, "/www/icons"),
+    overwrite = TRUE
   )
   ui_done("pwa-utils successfully copied to /www!")
 


### PR DESCRIPTION
I was trying to run `set_pwa` for the second time as the book told me that actually run `set_pwa` with `register_service_worker = FALSE`. It was difficult to get it to run without fully deleting the application folder as `fs::copy()` would not overwrite the files.

I thought I was ok, but didn't copy over the icons folder... that took too long to figure out that _that_ is why I couldn't install my application.

--------------

`overwrite` should always be enabled as other files (ex: `srcjs/sw-register.js`) are blindly writing as well.