### PR TITLE
fix reference script for bindings

### DIFF
--- a/R/create_files.R
+++ b/R/create_files.R
@@ -20,7 +20,7 @@ create_input_binding <- function(name, pkg = ".", dir = "srcjs", open = TRUE,
   )
 
   # Add entry to main.js
-  if (add_reference) reference_script(name)
+  if (add_reference) reference_script(sprintf('input-%s',name))
 }
 
 #' Create a shiny output binding boilerplate
@@ -40,7 +40,7 @@ create_output_binding <- function(name, pkg = ".", dir = "srcjs", open = TRUE,
   )
 
   # Add entry to main.js
-  if (add_reference) reference_script(name)
+  if (add_reference) reference_script(sprintf('output-%s',name))
 }
 
 #' Create a shiny custom handler boilerplate


### PR DESCRIPTION
When using `create_input_binding` and `create_output_binding`, the call to `reference_script` does not acknowledge the fact that there there is an `input-` and `output-` prefix, respectively, to the JS files created by golem. This leads to an error when running `build_js()` because the files get added to `main.js` without those prefixes. 